### PR TITLE
[docs]: adicionar configuração inicial do Swagger para documentação da API

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import morgan from 'morgan';
 
 import projectsRouter from './routes/projects.routes';
 import tasksRouter from './routes/tasks.routes';
+import { setupSwagger } from './swagger';
 
 /** Express */
 export const app = express();
@@ -62,6 +63,9 @@ app.use('/', tasksRouter);
 
 /** Logger */
 app.use(morgan('dev'));
+
+/** Swagger */
+setupSwagger(app);
 
 /** Health check */
 app.get('/health', (_req: Request, res: Response) => {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,26 @@
+import { Express } from 'express';
+import swaggerJSDoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
+const options: swaggerJSDoc.Options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Gerenciador de Projetos e Tarefas',
+      version: '1.0.0',
+      description: 'API para gerenciamento de projetos e tarefas',
+    },
+    servers: [
+      {
+        url: `http://localhost:${process.env.PORT || 3000}`,
+      },
+    ],
+  },
+  apis: ['./src/routes/**/*.ts', './src/controllers/**/*.ts'],
+};
+
+const swaggerSpec = swaggerJSDoc(options);
+
+export const setupSwagger = (app: Express) => {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+};


### PR DESCRIPTION
# Descrição da PR
Este PR adiciona a configuração inicial do Swagger, permitindo acesso à documentação da API via rota /api-docs.
Foram definidas informações básicas da API (versão, título e descrição), além da estrutura para futura documentação dos endpoints de Projects e Tasks.

---

# Tipo de mudança

- [ ] Nova funcionalidade (feat)
- [ ] Correção de bug (fix)
- [ ] Refatoração (refactor)
- [ ] Ajustes de configuração (chore)
- [x] Documentação (docs)
- [ ] Testes (test)

---

# Alterações realizadas
- Criado arquivo swagger.ts para centralizar definições do Swagger

- Adicionada rota /api-docs no server.ts para acesso à documentação

---

# Como testar
Passos sugeridos para validar esta PR:

1. Estar executando o projeto com o docker:
docker compose up -d

2. Acessar a documentação no navegador:
http://localhost:3000/api-docs

---