### PR TITLE
test: adicionar testes e2e, unitários e configuração de setup

### DIFF
--- a/tests/e2e/health.e2e.spec.ts
+++ b/tests/e2e/health.e2e.spec.ts
@@ -1,0 +1,13 @@
+import request from 'supertest';
+import { app } from '../../src/server';
+
+describe('Health', () => {
+  it('GET /health -> 200', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ok',
+      message: expect.stringContaining('This is the way'),
+    });
+  });
+});

--- a/tests/e2e/projects.e2e.spec.ts
+++ b/tests/e2e/projects.e2e.spec.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import { app } from '../../src/server';
+import { truncateAll } from '../helpers/db';
+
+describe('Projects E2E', () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('POST /projects → cria projeto', async () => {
+    // Cenário: cria projeto
+    const payload = {
+      name: 'Projeto inserido E2E',
+      description: 'Primeiro projeto criado pelo E2E',
+      status: 'active',
+    };
+
+    const res = await request(app).post('/projects').send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        name: payload.name,
+        description: payload.description,
+        status: payload.status,
+      }),
+    );
+  });
+
+  it('GET /projects → lista projetos', async () => {
+    // Cenário: cria projeto
+    await request(app).post('/projects').send({
+      name: 'A',
+      description: 'Projeto A',
+      status: 'active',
+    });
+    const res = await request(app).get('/projects');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toEqual(
+      expect.objectContaining({ id: expect.any(Number), name: expect.any(String) }),
+    );
+  });
+
+  it('GET /projects/:id → retorna dados do projeto', async () => {
+    // Cenário: cria projeto
+    const create = await request(app).post('/projects').send({
+      name: 'B',
+      description: 'Projeto B',
+      status: 'active',
+    });
+    const id = create.body.id;
+
+    const res = await request(app).get(`/projects/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ id, name: 'B' }));
+  });
+
+  it('PUT /projects/:id → atualiza projeto', async () => {
+    // Cenário: cria projeto
+    const create = await request(app).post('/projects').send({
+      name: 'D',
+      description: 'Projeto D',
+      status: 'active',
+    });
+    const id = create.body.id;
+
+    const res = await request(app).put(`/projects/${id}`).send({
+      name: 'C atualizado',
+      description: 'Descrição atualizada',
+      status: 'active',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({ id, name: 'C atualizado', description: 'Descrição atualizada' }),
+    );
+  });
+
+  it('DELETE /projects/:id → remove projeto', async () => {
+    // Cenário: cria projeto
+    const create = await request(app).post('/projects').send({ name: 'D', description: 'Projeto D', status: 'active' });
+    const id = create.body.id;
+
+    const res = await request(app).delete(`/projects/${id}`);
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/e2e/tasks.e2e.spec.ts
+++ b/tests/e2e/tasks.e2e.spec.ts
@@ -1,0 +1,116 @@
+import request from 'supertest';
+
+import { sequelize } from '../../src/models';
+import { app } from '../../src/server';
+import { truncateAll } from '../helpers/db';
+
+describe('Tasks E2E', () => {
+  beforeAll(async () => {
+    await sequelize.authenticate();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  it('POST /projects/:projectId/tasks → cria tarefa vinculada ao projeto', async () => {
+    // Cenário: cria projeto
+    const project = await request(app).post('/projects').send({
+      name: 'Projeto para tarefas',
+      description: 'Projeto para testar tarefas',
+      status: 'active',
+    });
+    expect(project.status).toBe(201);
+    const projectId: number = project.body.id;
+
+    const payload = {
+      title: 'Tarefa testar E2E',
+      description: 'Testar os endpoints no E2E e validar.',
+      status: 'pending',
+    };
+
+    const res = await request(app).post(`/projects/${projectId}/tasks`).send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        projectId,
+        title: payload.title,
+        status: payload.status,
+      }),
+    );
+  });
+
+  it('PUT /tasks/:id → atualiza status/título/descrição da tarefa', async () => {
+    // Cenário: cria projeto + tarefa
+    const project = await request(app)
+      .post('/projects')
+      .send({ name: 'Projeto', description: 'Projeto para testar tarefas', status: 'active' });
+    const projectId: number = project.body.id;
+
+    const task = await request(app)
+      .post(`/projects/${projectId}/tasks`)
+      .send({ title: 'Tarefa inicial', description: 'Primeira tarefa', status: 'pending' });
+    expect(task.status).toBe(201);
+
+    // Cenário: atualiza a tarefa
+    const res = await request(app).put(`/tasks/${task.body.id}`).send({ status: 'done' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        id: task.body.id,
+        status: 'done',
+      }),
+    );
+  });
+
+  it('DELETE /tasks/:id → remove tarefa', async () => {
+    // Cenário: cria projeto + tarefa
+    const project = await request(app)
+      .post('/projects')
+      .send({ name: 'Proj', description: 'Projeto', status: 'active' });
+    const projectId: number = project.body.id;
+
+    const task = await request(app)
+      .post(`/projects/${projectId}/tasks`)
+      .send({ title: 'Para remover', description: 'Primeira tarefa', status: 'pending' });
+    expect(task.status).toBe(201);
+
+    // Cenário: remove a tarefa
+    const res = await request(app).delete(`/tasks/${task.body.id}`);
+    expect(res.status).toBe(204);
+  });
+
+  it('POST /projects/:projectId/tasks → 404 se projectId não existe', async () => {
+    const res = await request(app)
+      .post('/projects/999999/tasks')
+      .send({ title: 'Orfã', description: 'Primeira tarefa', status: 'pending' });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /projects/:projectId/tasks → 422 sem title', async () => {
+    const project = await request(app)
+      .post('/projects')
+      .send({ name: 'P', description: 'P', status: 'active' });
+    const projectId: number = project.body.id;
+
+    const res = await request(app).post(`/projects/${projectId}/tasks`).send({ status: 'pending' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /projects/:projectId/tasks → 422 com status inválido', async () => {
+    const project = await request(app)
+      .post('/projects')
+      .send({ name: 'P', description: 'P', status: 'active' });
+    const projectId: number = project.body.id;
+
+    const res = await request(app)
+      .post(`/projects/${projectId}/tasks`)
+      .send({ title: 'T1', status: 'not-a-valid-status' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,32 @@
+import { sequelize } from '../../src/models';
+
+/**
+ * Trunca todas as tabelas registradas no Sequelize (MySQL).
+ * - Desabilita FOREIGN_KEY_CHECKS para não precisar de ordem.
+ * - Reseta AUTO_INCREMENT automaticamente (TRUNCATE).
+ * - Usa destroy({ truncate: true, restartIdentity: true, cascade: true }) para models.
+ */
+export async function truncateAll() {
+  // Desliga checagem de FKs
+  await sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
+
+  // 1) Trunca tabelas conhecidas via models
+  const models = Object.values(sequelize.models);
+  for (const model of models) {
+    await (model as any).destroy({
+      where: {},
+      truncate: true,
+      force: true,
+      restartIdentity: true,
+      cascade: true,
+    });
+  }
+
+  // Religa checagem de FKs
+  await sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+}
+
+/** Fecha o pool de conexões (útil em teardown global do Jest). */
+export async function closeDb() {
+  await sequelize.close();
+}

--- a/tests/jest.globalSetup.ts
+++ b/tests/jest.globalSetup.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process';
+
+module.exports = async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.DB_NAME = process.env.DB_NAME ? `${process.env.DB_NAME}_test` : 'projects_db_test';
+
+  try {
+    execSync('npx sequelize-cli db:migrate --env test', { stdio: 'inherit' });
+  } catch (e) {
+    console.error('Falha ao rodar migrations de teste', e);
+    throw e;
+  }
+};

--- a/tests/jest.globalTeardown.ts
+++ b/tests/jest.globalTeardown.ts
@@ -1,0 +1,9 @@
+import { execSync } from 'node:child_process';
+
+module.exports = async () => {
+  try {
+    execSync('npx sequelize-cli db:migrate:undo:all --env test', { stdio: 'inherit' });
+  } catch (e) {
+    console.error('Falha ao desfazer migrations de teste', e);
+  }
+};

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,0 +1,6 @@
+jest.setTimeout(30_000);
+
+jest.mock('ioredis', () => {
+  const RedisMock = require('ioredis-mock');
+  return RedisMock;
+});

--- a/tests/unit/controllers/projects.controller.test.ts
+++ b/tests/unit/controllers/projects.controller.test.ts
@@ -1,0 +1,212 @@
+import { ProjectsController } from '../../../src/controllers/projects.controller';
+import { GitHubService } from '../../../src/services/github.service';
+import { ProjectsService } from '../../../src/services/projects.service';
+
+jest.mock('../../../src/services/projects.service');
+jest.mock('../../../src/services/github.service');
+
+type MockReq = Partial<{ body: any; params: any }>;
+type MockRes = { status: jest.Mock; json: jest.Mock; send: jest.Mock };
+type MockNext = jest.Mock;
+
+function getMockRes(): MockRes {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('ProjectsController', () => {
+  let req: MockReq;
+  let res: MockRes;
+  let next: MockNext;
+
+  beforeEach(() => {
+    req = { body: {}, params: {} };
+    res = getMockRes();
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    // Cenário: Criação de projeto bem-sucedida retorna status 201 e o projeto criado
+    it('deve criar projeto e retornar 201', async () => {
+      (ProjectsService.create as jest.Mock).mockResolvedValue({ id: 1, name: 'Projeto' });
+      req.body = { name: 'Projeto' };
+      await ProjectsController.create(req as any, res as any, next);
+      expect(ProjectsService.create).toHaveBeenCalledWith(req.body);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: 1, name: 'Projeto' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao criar projeto deve chamar next com erro
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (ProjectsService.create as jest.Mock).mockRejectedValue(error);
+      await ProjectsController.create(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: Corpo vazio ainda chama service (edge case)
+    it('deve aceitar body vazio', async () => {
+      (ProjectsService.create as jest.Mock).mockResolvedValue({ id: 2 });
+      req.body = {};
+      await ProjectsController.create(req as any, res as any, next);
+      expect(ProjectsService.create).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: 2 });
+    });
+  });
+
+  describe('list', () => {
+    // Cenário: Listagem bem-sucedida retorna lista de projetos
+    it('deve listar projetos', async () => {
+      (ProjectsService.list as jest.Mock).mockResolvedValue([{ id: 1 }]);
+      await ProjectsController.list(req as any, res as any, next);
+      expect(ProjectsService.list).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao listar projetos deve chamar next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (ProjectsService.list as jest.Mock).mockRejectedValue(error);
+      await ProjectsController.list(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('get', () => {
+    // Cenário: Busca de projeto por ID retorna projeto
+    it('deve retornar projeto pelo id', async () => {
+      (ProjectsService.get as jest.Mock).mockResolvedValue({ id: 1 });
+      req.params = { id: '1' };
+      await ProjectsController.get(req as any, res as any, next);
+      expect(ProjectsService.get).toHaveBeenCalledWith(1);
+      expect(res.json).toHaveBeenCalledWith({ id: 1 });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao buscar projeto chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('not found');
+      (ProjectsService.get as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1' };
+      await ProjectsController.get(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: ID inválido (edge case)
+    it('deve passar NaN para service se id inválido', async () => {
+      (ProjectsService.get as jest.Mock).mockResolvedValue(null);
+      req.params = { id: 'abc' };
+      await ProjectsController.get(req as any, res as any, next);
+      expect(ProjectsService.get).toHaveBeenCalledWith(NaN);
+    });
+  });
+
+  describe('update', () => {
+    // Cenário: Atualização bem-sucedida retorna projeto atualizado
+    it('deve atualizar projeto', async () => {
+      (ProjectsService.update as jest.Mock).mockResolvedValue({ id: 1, name: 'Novo' });
+      req.params = { id: '1' };
+      req.body = { name: 'Novo' };
+      await ProjectsController.update(req as any, res as any, next);
+      expect(ProjectsService.update).toHaveBeenCalledWith(1, req.body);
+      expect(res.json).toHaveBeenCalledWith({ id: 1, name: 'Novo' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao atualizar projeto chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (ProjectsService.update as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1' };
+      req.body = { name: 'Novo' };
+      await ProjectsController.update(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: Body vazio ainda chama service (edge case)
+    it('deve aceitar body vazio', async () => {
+      (ProjectsService.update as jest.Mock).mockResolvedValue({ id: 1 });
+      req.params = { id: '1' };
+      req.body = {};
+      await ProjectsController.update(req as any, res as any, next);
+      expect(ProjectsService.update).toHaveBeenCalledWith(1, {});
+      expect(res.json).toHaveBeenCalledWith({ id: 1 });
+    });
+  });
+
+  describe('remove', () => {
+    // Cenário: Remoção bem-sucedida retorna 204
+    it('deve remover projeto', async () => {
+      (ProjectsService.remove as jest.Mock).mockResolvedValue(undefined);
+      req.params = { id: '1' };
+      await ProjectsController.remove(req as any, res as any, next);
+      expect(ProjectsService.remove).toHaveBeenCalledWith(1);
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao remover projeto chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (ProjectsService.remove as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1' };
+      await ProjectsController.remove(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: ID inválido (edge case)
+    it('deve passar NaN para service se id inválido', async () => {
+      (ProjectsService.remove as jest.Mock).mockResolvedValue(undefined);
+      req.params = { id: 'abc' };
+      await ProjectsController.remove(req as any, res as any, next);
+      expect(ProjectsService.remove).toHaveBeenCalledWith(NaN);
+    });
+  });
+
+  describe('githubAttach', () => {
+    // Cenário: Associação ao GitHub bem-sucedida retorna dados
+    it('deve associar dados do github ao projeto', async () => {
+      (GitHubService.fetchAndAttach as jest.Mock).mockResolvedValue({ ok: true });
+      req.params = { id: '1', username: 'user' };
+      await ProjectsController.githubAttach(req as any, res as any, next);
+      expect(GitHubService.fetchAndAttach).toHaveBeenCalledWith(1, 'user');
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Falta username deve lançar erro 400
+    it('deve lançar erro se username ausente', async () => {
+      req.params = { id: '1' };
+      await ProjectsController.githubAttach(req as any, res as any, next);
+      expect(next).toHaveBeenCalled();
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.status).toBe(400);
+    });
+
+    // Cenário: Erro ao associar github chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (GitHubService.fetchAndAttach as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1', username: 'user' };
+      await ProjectsController.githubAttach(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: ID inválido (edge case)
+    it('deve passar NaN para service se id inválido', async () => {
+      (GitHubService.fetchAndAttach as jest.Mock).mockResolvedValue({ ok: true });
+      req.params = { id: 'abc', username: 'user' };
+      await ProjectsController.githubAttach(req as any, res as any, next);
+      expect(GitHubService.fetchAndAttach).toHaveBeenCalledWith(NaN, 'user');
+    });
+  });
+});

--- a/tests/unit/controllers/tasks.controller.test.ts
+++ b/tests/unit/controllers/tasks.controller.test.ts
@@ -1,0 +1,145 @@
+import { TasksController } from '../../../src/controllers/tasks.controller';
+import { TasksService } from '../../../src/services/tasks.service';
+
+jest.mock('../../../src/services/tasks.service');
+
+type MockReq = Partial<{ body: any; params: any }>;
+type MockRes = { status: jest.Mock; json: jest.Mock; send: jest.Mock };
+type MockNext = jest.Mock;
+
+function getMockRes(): MockRes {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('TasksController', () => {
+  let req: MockReq;
+  let res: MockRes;
+  let next: MockNext;
+
+  beforeEach(() => {
+    req = { body: {}, params: {} };
+    res = getMockRes();
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    // Cenário: Criação de tarefa bem-sucedida retorna status 201 e a tarefa criada
+    it('deve criar tarefa e retornar 201', async () => {
+      (TasksService.create as jest.Mock).mockResolvedValue({ id: 1, title: 'Tarefa' });
+      req.body = { title: 'Tarefa' };
+      req.params = { projectId: '2' };
+      await TasksController.create(req as any, res as any, next);
+      expect(TasksService.create).toHaveBeenCalledWith(2, req.body);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: 1, title: 'Tarefa' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao criar tarefa deve chamar next com erro
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (TasksService.create as jest.Mock).mockRejectedValue(error);
+      req.body = { title: 'Tarefa' };
+      req.params = { projectId: '2' };
+      await TasksController.create(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: Body vazio ainda chama service (edge case)
+    it('deve aceitar body vazio', async () => {
+      (TasksService.create as jest.Mock).mockResolvedValue({ id: 2 });
+      req.body = {};
+      req.params = { projectId: '2' };
+      await TasksController.create(req as any, res as any, next);
+      expect(TasksService.create).toHaveBeenCalledWith(2, {});
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: 2 });
+    });
+
+    // Cenário: projectId inválido (edge case)
+    it('deve passar NaN para service se projectId inválido', async () => {
+      (TasksService.create as jest.Mock).mockResolvedValue({ id: 3 });
+      req.body = { title: 'Tarefa' };
+      req.params = { projectId: 'abc' };
+      await TasksController.create(req as any, res as any, next);
+      expect(TasksService.create).toHaveBeenCalledWith(NaN, req.body);
+    });
+  });
+
+  describe('update', () => {
+    // Cenário: Atualização bem-sucedida retorna tarefa atualizada
+    it('deve atualizar tarefa', async () => {
+      (TasksService.update as jest.Mock).mockResolvedValue({ id: 1, title: 'Nova' });
+      req.params = { id: '1' };
+      req.body = { title: 'Nova' };
+      await TasksController.update(req as any, res as any, next);
+      expect(TasksService.update).toHaveBeenCalledWith(1, req.body);
+      expect(res.json).toHaveBeenCalledWith({ id: 1, title: 'Nova' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao atualizar tarefa chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (TasksService.update as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1' };
+      req.body = { title: 'Nova' };
+      await TasksController.update(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: Body vazio ainda chama service (edge case)
+    it('deve aceitar body vazio', async () => {
+      (TasksService.update as jest.Mock).mockResolvedValue({ id: 1 });
+      req.params = { id: '1' };
+      req.body = {};
+      await TasksController.update(req as any, res as any, next);
+      expect(TasksService.update).toHaveBeenCalledWith(1, {});
+      expect(res.json).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    // Cenário: id inválido (edge case)
+    it('deve passar NaN para service se id inválido', async () => {
+      (TasksService.update as jest.Mock).mockResolvedValue({ id: 2 });
+      req.params = { id: 'abc' };
+      req.body = { title: 'Nova' };
+      await TasksController.update(req as any, res as any, next);
+      expect(TasksService.update).toHaveBeenCalledWith(NaN, req.body);
+    });
+  });
+
+  describe('remove', () => {
+    // Cenário: Remoção bem-sucedida retorna 204
+    it('deve remover tarefa', async () => {
+      (TasksService.remove as jest.Mock).mockResolvedValue(undefined);
+      req.params = { id: '1' };
+      await TasksController.remove(req as any, res as any, next);
+      expect(TasksService.remove).toHaveBeenCalledWith(1);
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // Cenário: Erro ao remover tarefa chama next
+    it('deve chamar next em caso de erro', async () => {
+      const error = new Error('fail');
+      (TasksService.remove as jest.Mock).mockRejectedValue(error);
+      req.params = { id: '1' };
+      await TasksController.remove(req as any, res as any, next);
+      expect(next).toHaveBeenCalledWith(error);
+    });
+
+    // Cenário: id inválido (edge case)
+    it('deve passar NaN para service se id inválido', async () => {
+      (TasksService.remove as jest.Mock).mockResolvedValue(undefined);
+      req.params = { id: 'abc' };
+      await TasksController.remove(req as any, res as any, next);
+      expect(TasksService.remove).toHaveBeenCalledWith(NaN);
+    });
+  });
+});

--- a/tests/unit/models/index.test.ts
+++ b/tests/unit/models/index.test.ts
@@ -1,0 +1,62 @@
+import { Sequelize } from 'sequelize';
+
+// Mocka dependências
+jest.mock('../../../src/models/project', () => ({
+  initProjectModel: jest.fn(),
+  Project: { hasMany: jest.fn() },
+}));
+
+jest.mock('../../../src/models/task', () => ({
+  initTaskModel: jest.fn(),
+  Task: { belongsTo: jest.fn() },
+}));
+
+describe('models/index', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('deve inicializar Sequelize com configs do env', () => {
+    process.env.DB_HOST = 'meu-host';
+    process.env.DB_PORT = '1234';
+    process.env.DB_USER = 'user';
+    process.env.DB_PASSWORD = 'senha';
+    process.env.DB_NAME = 'meu_db';
+    process.env.DB_LOGGING = 'false';
+
+    const { sequelize } = require('../../../src/models');
+
+    expect(sequelize.constructor.name).toBe('Sequelize');
+    expect(sequelize.options.host).toBe('meu-host');
+    expect(sequelize.options.port).toBe(1234);
+    expect(sequelize.config.database).toBe('meu_db');
+  });
+
+  it('deve chamar initProjectModel e initTaskModel com sequelize', () => {
+    const { sequelize } = require('../../../src/models');
+    const { initProjectModel } = require('../../../src/models/project');
+    const { initTaskModel } = require('../../../src/models/task');
+
+    expect(initProjectModel).toHaveBeenCalledWith(sequelize);
+    expect(initTaskModel).toHaveBeenCalledWith(sequelize);
+  });
+
+  it('deve configurar associações entre Project e Task', () => {
+    const { Project } = require('../../../src/models/project');
+    const { Task } = require('../../../src/models/task');
+
+    // importa para rodar os side-effects (associações)
+    require('../../../src/models');
+
+    expect(Project.hasMany).toHaveBeenCalledWith(Task, {
+      foreignKey: 'projectId',
+      as: 'tasks',
+      onDelete: 'CASCADE',
+    });
+
+    expect(Task.belongsTo).toHaveBeenCalledWith(Project, {
+      foreignKey: 'projectId',
+      as: 'project',
+    });
+  });
+});

--- a/tests/unit/models/project.test.ts
+++ b/tests/unit/models/project.test.ts
@@ -1,0 +1,155 @@
+import { Project, initProjectModel } from '../../../src/models/project';
+
+// ---- Mock do Sequelize: Model com construtor NO-OP e DataTypes espiados ----
+jest.mock('sequelize', () => {
+  // DataTypes spies (registram parâmetros usados no init)
+  const STRING = jest.fn((len?: number) => ({ type: 'STRING', len }));
+  const TEXT = jest.fn(() => ({ type: 'TEXT' }));
+  const ENUM = jest.fn((...vals: string[]) => ({ type: 'ENUM', vals }));
+  const JSON = jest.fn(() => ({ type: 'JSON' }));
+  const DATE = jest.fn(() => ({ type: 'DATE' }));
+  const INTEGER = {
+    UNSIGNED: { type: 'INTEGER.UNSIGNED' },
+  };
+  const NOW = 'NOW';
+
+  class MockModel {
+    constructor(..._args: any[]) {} // no-op
+    static init = jest.fn();
+    static hasOne = jest.fn();
+    static belongsTo = jest.fn();
+    static hasMany = jest.fn();
+    static belongsToMany = jest.fn();
+  }
+
+  const Sequelize = jest.fn(function SequelizeFake() {}) as any;
+
+  return {
+    Model: MockModel,
+    DataTypes: { STRING, TEXT, ENUM, JSON, DATE, NOW, INTEGER },
+    Sequelize,
+  };
+});
+
+// reimport depois do mock para capturar DataTypes/Model/Sequelize fake
+import { DataTypes, Sequelize, Model } from 'sequelize';
+
+describe('Project model (POJO behavior)', () => {
+  // Cenário: Instanciação simples sem tocar internals reais do Sequelize
+  it('deve instanciar Project e acessar campos obrigatórios', () => {
+    const p = new Project() as any;
+    p.id = 1;
+    p.name = 'Teste';
+    p.status = 'active';
+    p.createdAt = new Date();
+    p.updatedAt = new Date();
+    expect(p.id).toBe(1);
+    expect(p.name).toBe('Teste');
+    expect(p.status).toBe('active');
+    expect(p.createdAt).toBeInstanceOf(Date);
+    expect(p.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('deve permitir description e githubRepos nulos', () => {
+    const p = new Project() as any;
+    p.description = null;
+    p.githubRepos = null;
+    expect(p.description).toBeNull();
+    expect(p.githubRepos).toBeNull();
+  });
+
+  it('deve permitir description e githubRepos preenchidos', () => {
+    const p = new Project() as any;
+    p.description = 'desc';
+    p.githubRepos = { repo: 'test' };
+    expect(p.description).toBe('desc');
+    expect(p.githubRepos).toEqual({ repo: 'test' });
+  });
+
+  it('deve aceitar status archived', () => {
+    const p = new Project() as any;
+    p.status = 'archived';
+    expect(p.status).toBe('archived');
+  });
+});
+
+describe('initProjectModel (schema definition)', () => {
+  let sequelize: Sequelize;
+
+  beforeEach(() => {
+    sequelize = new (Sequelize as any)();
+    (Project.init as unknown as jest.Mock).mockClear();
+    (DataTypes.STRING as jest.Mock).mockClear();
+    (DataTypes.TEXT as jest.Mock).mockClear();
+    (DataTypes.ENUM as jest.Mock).mockClear();
+    (DataTypes.JSON as jest.Mock).mockClear();
+    (DataTypes.DATE as jest.Mock).mockClear();
+  });
+
+  it('deve inicializar modelo com campos e opções corretas', () => {
+    initProjectModel(sequelize);
+
+    expect(Project.init).toHaveBeenCalledTimes(1);
+    const [fields, options] = (Project.init as unknown as jest.Mock).mock.calls[0];
+
+    // Campos presentes
+    expect(fields).toHaveProperty('id');
+    expect(fields).toHaveProperty('name');
+    expect(fields).toHaveProperty('description');
+    expect(fields).toHaveProperty('status');
+    expect(fields).toHaveProperty('githubRepos');
+    expect(fields).toHaveProperty('createdAt');
+    expect(fields).toHaveProperty('updatedAt');
+
+    // Opções principais
+    expect(options).toMatchObject({
+      tableName: 'projects',
+      sequelize,
+      modelName: 'Project',
+      timestamps: true,
+      underscored: true,
+    });
+  });
+
+  it('deve usar DataTypes com parâmetros esperados', () => {
+    initProjectModel(sequelize);
+
+    expect(DataTypes.STRING).toHaveBeenCalledWith(120);
+    expect(DataTypes.ENUM).toHaveBeenCalledWith('active', 'archived');
+    expect(DataTypes.TEXT).toHaveBeenCalled();
+    expect(DataTypes.JSON).toHaveBeenCalled();
+    expect(DataTypes.DATE).toHaveBeenCalledTimes(2);
+  });
+
+  it('deve mapear githubRepos->github_repos e defaults corretos', () => {
+    initProjectModel(sequelize);
+    const [fields] = (Project.init as unknown as jest.Mock).mock.calls[0];
+
+    expect(fields.githubRepos.field).toBe('github_repos');
+    expect(fields.githubRepos.defaultValue).toBeNull();
+    expect(fields.description.defaultValue).toBeNull();
+
+    // status default
+    expect(fields.status.defaultValue).toBe('active');
+
+    // createdAt / updatedAt defaults
+    expect(fields.createdAt.defaultValue).toBe(DataTypes.NOW);
+    expect(fields.updatedAt.defaultValue).toBe(DataTypes.NOW);
+  });
+
+  it('deve expor apenas os valores permitidos no ENUM status', () => {
+    initProjectModel(sequelize);
+    expect((DataTypes.ENUM as jest.Mock).mock.calls[0][0]).toBe('active');
+    expect((DataTypes.ENUM as jest.Mock).mock.calls[0][1]).toBe('archived');
+    expect((DataTypes.ENUM as jest.Mock).mock.calls[0]).toHaveLength(2);
+  });
+
+  it('deve inicializar mesmo com sequelize undefined/null e suportar chamadas repetidas', () => {
+    expect(() => initProjectModel(undefined as any)).not.toThrow();
+    expect(() => initProjectModel(null as any)).not.toThrow();
+
+    // chamada adicional com sequelize válido
+    initProjectModel(sequelize);
+    expect(Project.init).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/models/task.test.ts
+++ b/tests/unit/models/task.test.ts
@@ -1,0 +1,155 @@
+import { Task, initTaskModel } from '../../../src/models/task';
+
+// ---- Mock do Sequelize: Model com construtor NO-OP e DataTypes espiados ----
+jest.mock('sequelize', () => {
+  const STRING = jest.fn((len?: number) => ({ type: 'STRING', len }));
+  const TEXT = jest.fn(() => ({ type: 'TEXT' }));
+  const ENUM = jest.fn((...vals: string[]) => ({ type: 'ENUM', vals }));
+  const INTEGER = { UNSIGNED: true }; // usado em id / projectId
+  const DATE = jest.fn(() => ({ type: 'DATE' }));
+  const NOW = 'NOW';
+
+  class MockModel {
+    constructor(..._args: any[]) {} // no-op
+    static init = jest.fn();
+    static hasOne = jest.fn();
+    static belongsTo = jest.fn();
+    static hasMany = jest.fn();
+    static belongsToMany = jest.fn();
+  }
+
+  const Sequelize = jest.fn(function SequelizeFake() {}) as any;
+
+  return {
+    Model: MockModel,
+    DataTypes: { STRING, TEXT, ENUM, INTEGER, DATE, NOW },
+    Sequelize,
+  };
+});
+
+// reimport depois do mock para capturar DataTypes/Sequelize mockados
+import { DataTypes, Sequelize } from 'sequelize';
+
+describe('Task model (POJO)', () => {
+  // Cenário: Instanciação simples e campos obrigatórios
+  it('deve instanciar Task e acessar campos obrigatórios', () => {
+    const t = new Task() as any;
+    t.id = 1;
+    t.projectId = 10;
+    t.title = 'Nova tarefa';
+    t.status = 'pending';
+    t.createdAt = new Date();
+    t.updatedAt = new Date();
+
+    expect(t.id).toBe(1);
+    expect(t.projectId).toBe(10);
+    expect(t.title).toBe('Nova tarefa');
+    expect(t.status).toBe('pending');
+    expect(t.createdAt).toBeInstanceOf(Date);
+    expect(t.updatedAt).toBeInstanceOf(Date);
+  });
+
+  // Cenário: Campos opcionais
+  it('deve permitir description nulo e preenchido', () => {
+    const a = new Task() as any;
+    a.description = null;
+    expect(a.description).toBeNull();
+
+    const b = new Task() as any;
+    b.description = 'detalhe';
+    expect(b.description).toBe('detalhe');
+  });
+
+  // Cenário: Status válidos
+  it('deve aceitar status in_progress e done', () => {
+    const a = new Task() as any;
+    a.status = 'in_progress';
+    expect(a.status).toBe('in_progress');
+
+    const b = new Task() as any;
+    b.status = 'done';
+    expect(b.status).toBe('done');
+  });
+});
+
+describe('initTaskModel (schema)', () => {
+  let sequelize: Sequelize;
+
+  beforeEach(() => {
+    sequelize = new (Sequelize as any)();
+    (Task.init as unknown as jest.Mock).mockClear();
+    (DataTypes.STRING as jest.Mock).mockClear?.();
+    (DataTypes.TEXT as jest.Mock).mockClear?.();
+    (DataTypes.ENUM as jest.Mock).mockClear?.();
+    (DataTypes.DATE as jest.Mock).mockClear?.();
+  });
+
+  // Campos e opções básicas
+  it('deve inicializar com campos e opções corretas', () => {
+    initTaskModel(sequelize);
+
+    expect(Task.init).toHaveBeenCalledTimes(1);
+    const [fields, options] = (Task.init as unknown as jest.Mock).mock.calls[0];
+
+    // Campos esperados
+    expect(fields).toHaveProperty('id');
+    expect(fields).toHaveProperty('projectId');
+    expect(fields).toHaveProperty('title');
+    expect(fields).toHaveProperty('description');
+    expect(fields).toHaveProperty('status');
+    expect(fields).toHaveProperty('createdAt');
+    expect(fields).toHaveProperty('updatedAt');
+
+    // Opções principais
+    expect(options).toMatchObject({
+      tableName: 'tasks',
+      sequelize,
+    });
+  });
+
+  // DataTypes chamados com parâmetros corretos
+  it('deve usar DataTypes esperados', () => {
+    initTaskModel(sequelize);
+
+    const [fields] = (Task.init as unknown as jest.Mock).mock.calls[0];
+
+    // title STRING(120) (aqui é função mesmo)
+    expect(DataTypes.STRING as jest.Mock).toHaveBeenCalledWith(120);
+
+    // description usa TEXT como valor (não é chamado)
+    expect(fields.description.type).toBe(DataTypes.TEXT);
+
+    // status é ENUM(...), esse sim é chamado
+    expect(DataTypes.ENUM as jest.Mock).toHaveBeenCalledWith('pending', 'in_progress', 'done');
+
+    // createdAt/updatedAt usam DATE como valor (não é chamado)
+    expect(fields.createdAt.type).toBe(DataTypes.DATE);
+    expect(fields.updatedAt.type).toBe(DataTypes.DATE);
+
+    // (opcional) conferir INTEGER.UNSIGNED no projectId
+    expect(fields.projectId.type).toBe(DataTypes.INTEGER.UNSIGNED);
+  });
+
+  // Mapeamentos snake_case, defaults etc.
+  it('deve mapear projectId->project_id e ter default/status corretos', () => {
+    initTaskModel(sequelize);
+    const [fields] = (Task.init as unknown as jest.Mock).mock.calls[0];
+
+    // mapeamentos
+    expect(fields.projectId.field).toBe('project_id');
+    expect(fields.createdAt.field).toBe('created_at');
+    expect(fields.updatedAt.field).toBe('updated_at');
+
+    // defaults
+    expect(fields.status.defaultValue).toBe('pending');
+  });
+
+  // Edge cases: chamadas repetidas e sequelize ausente
+  it('deve inicializar mesmo com sequelize undefined/null e suportar múltiplas chamadas', () => {
+    expect(() => initTaskModel(undefined as any)).not.toThrow();
+    expect(() => initTaskModel(null as any)).not.toThrow();
+
+    initTaskModel(sequelize);
+    expect(Task.init).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/repositories/projects.repo.test.ts
+++ b/tests/unit/repositories/projects.repo.test.ts
@@ -1,0 +1,155 @@
+import { Project } from '../../../src/models/project';
+import { Task } from '../../../src/models/task';
+import { ProjectsRepo } from '../../../src/repositories/projects.repo';
+
+jest.mock('../../../src/models/project');
+jest.mock('../../../src/models/task');
+
+describe('ProjectsRepo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    // Cenário: Criação de projeto bem-sucedida
+    it('deve criar projeto', async () => {
+      // Arrange
+      (Project.create as jest.Mock).mockResolvedValue({ id: 1 });
+      const data = { name: 'Projeto' };
+      // Act
+      const result = await ProjectsRepo.create(data);
+      // Assert
+      expect(Project.create).toHaveBeenCalledWith(data);
+      expect(result).toEqual({ id: 1 });
+    });
+
+    // Cenário: Dados vazios
+    it('deve criar projeto com dados vazios', async () => {
+      (Project.create as jest.Mock).mockResolvedValue({ id: 2 });
+      const result = await ProjectsRepo.create({});
+      expect(Project.create).toHaveBeenCalledWith({});
+      expect(result).toEqual({ id: 2 });
+    });
+
+    // Cenário: Erro ao criar projeto
+    it('deve propagar erro de Project.create', async () => {
+      const error = new Error('fail');
+      (Project.create as jest.Mock).mockRejectedValue(error);
+      await expect(ProjectsRepo.create({})).rejects.toThrow(error);
+    });
+  });
+
+  describe('findAll', () => {
+    // Cenário: Busca de todos os projetos
+    it('deve buscar todos os projetos', async () => {
+      (Project.findAll as jest.Mock).mockResolvedValue([{ id: 1 }]);
+      const result = await ProjectsRepo.findAll();
+      expect(Project.findAll).toHaveBeenCalledWith({
+        include: [{ model: Task, as: 'tasks' }],
+      });
+      expect(result).toEqual([{ id: 1 }]);
+    });
+
+    // Cenário: Busca com opções customizadas
+    it('deve buscar projetos com opções customizadas', async () => {
+      (Project.findAll as jest.Mock).mockResolvedValue([{ id: 2 }]);
+      const options = { where: { status: 'active' } };
+      const result = await ProjectsRepo.findAll(options);
+      expect(Project.findAll).toHaveBeenCalledWith({
+        include: [{ model: Task, as: 'tasks' }],
+        ...options,
+      });
+      expect(result).toEqual([{ id: 2 }]);
+    });
+
+    // Cenário: Erro ao buscar projetos
+    it('deve propagar erro de Project.findAll', async () => {
+      const error = new Error('fail');
+      (Project.findAll as jest.Mock).mockRejectedValue(error);
+      await expect(ProjectsRepo.findAll()).rejects.toThrow(error);
+    });
+  });
+
+  describe('findById', () => {
+    // Cenário: Busca por ID retorna projeto
+    it('deve buscar projeto por id', async () => {
+      (Project.findByPk as jest.Mock).mockResolvedValue({ id: 1 });
+      const result = await ProjectsRepo.findById(1);
+      expect(Project.findByPk).toHaveBeenCalledWith(1, {
+        include: [{ model: Task, as: 'tasks' }],
+      });
+      expect(result).toEqual({ id: 1 });
+    });
+
+    // Cenário: Busca por ID não encontrado
+    it('deve retornar null se não encontrar projeto', async () => {
+      (Project.findByPk as jest.Mock).mockResolvedValue(null);
+      const result = await ProjectsRepo.findById(999);
+      expect(result).toBeNull();
+    });
+
+    // Cenário: Erro ao buscar projeto por id
+    it('deve propagar erro de Project.findByPk', async () => {
+      const error = new Error('fail');
+      (Project.findByPk as jest.Mock).mockRejectedValue(error);
+      await expect(ProjectsRepo.findById(1)).rejects.toThrow(error);
+    });
+  });
+
+  describe('updateById', () => {
+    // Cenário: Atualização bem-sucedida
+    it('deve atualizar projeto existente', async () => {
+      const mockProject = { update: jest.fn().mockResolvedValue({ id: 1, name: 'Novo' }) };
+      (Project.findByPk as jest.Mock).mockResolvedValue(mockProject);
+      const result = await ProjectsRepo.updateById(1, { name: 'Novo' });
+      expect(Project.findByPk).toHaveBeenCalledWith(1);
+      expect(mockProject.update).toHaveBeenCalledWith({ name: 'Novo' });
+      expect(result).toEqual({ id: 1, name: 'Novo' });
+    });
+
+    // Cenário: Projeto não encontrado retorna null
+    it('deve retornar null se projeto não encontrado', async () => {
+      (Project.findByPk as jest.Mock).mockResolvedValue(null);
+      const result = await ProjectsRepo.updateById(999, { name: 'Novo' });
+      expect(result).toBeNull();
+    });
+
+    // Cenário: Erro ao buscar projeto
+    it('deve propagar erro de Project.findByPk', async () => {
+      const error = new Error('fail');
+      (Project.findByPk as jest.Mock).mockRejectedValue(error);
+      await expect(ProjectsRepo.updateById(1, { name: 'Novo' })).rejects.toThrow(error);
+    });
+
+    // Cenário: Erro ao atualizar projeto
+    it('deve propagar erro de project.update', async () => {
+      const mockProject = { update: jest.fn().mockRejectedValue(new Error('update fail')) };
+      (Project.findByPk as jest.Mock).mockResolvedValue(mockProject);
+      await expect(ProjectsRepo.updateById(1, { name: 'Novo' })).rejects.toThrow('update fail');
+    });
+  });
+
+  describe('deleteById', () => {
+    // Cenário: Remoção bem-sucedida
+    it('deve remover projeto por id', async () => {
+      (Project.destroy as jest.Mock).mockResolvedValue(1);
+      const result = await ProjectsRepo.deleteById(1);
+      expect(Project.destroy).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(result).toBe(1);
+    });
+
+    // Cenário: Remoção retorna 0 (não encontrado)
+    it('deve retornar 0 se projeto não encontrado', async () => {
+      (Project.destroy as jest.Mock).mockResolvedValue(0);
+      const result = await ProjectsRepo.deleteById(999);
+      expect(result).toBe(0);
+    });
+
+    // Cenário: Erro ao remover projeto
+    it('deve propagar erro de Project.destroy', async () => {
+      const error = new Error('fail');
+      (Project.destroy as jest.Mock).mockRejectedValue(error);
+      await expect(ProjectsRepo.deleteById(1)).rejects.toThrow(error);
+    });
+  });
+});

--- a/tests/unit/repositories/tasks.repo.test.ts
+++ b/tests/unit/repositories/tasks.repo.test.ts
@@ -1,0 +1,117 @@
+import { Task } from '../../../src/models/task';
+import { TasksRepo } from '../../../src/repositories/tasks.repo';
+
+jest.mock('../../../src/models/task');
+
+describe('TasksRepo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    // Cenário: Criação de tarefa bem-sucedida
+    it('deve criar tarefa', async () => {
+      (Task.create as jest.Mock).mockResolvedValue({ id: 1 });
+      const data = { title: 'Tarefa' };
+      const result = await TasksRepo.create(data);
+      expect(Task.create).toHaveBeenCalledWith(data);
+      expect(result).toEqual({ id: 1 });
+    });
+
+    // Cenário: Dados vazios
+    it('deve criar tarefa com dados vazios', async () => {
+      (Task.create as jest.Mock).mockResolvedValue({ id: 2 });
+      const result = await TasksRepo.create({});
+      expect(Task.create).toHaveBeenCalledWith({});
+      expect(result).toEqual({ id: 2 });
+    });
+
+    // Cenário: Erro ao criar tarefa
+    it('deve propagar erro de Task.create', async () => {
+      const error = new Error('fail');
+      (Task.create as jest.Mock).mockRejectedValue(error);
+      await expect(TasksRepo.create({})).rejects.toThrow(error);
+    });
+  });
+
+  describe('updateById', () => {
+    // Cenário: Atualização bem-sucedida
+    it('deve atualizar tarefa existente', async () => {
+      const mockTask = { update: jest.fn().mockResolvedValue({ id: 1, title: 'Novo' }) };
+      (Task.findByPk as jest.Mock).mockResolvedValue(mockTask);
+      const result = await TasksRepo.updateById(1, { title: 'Novo' });
+      expect(Task.findByPk).toHaveBeenCalledWith(1);
+      expect(mockTask.update).toHaveBeenCalledWith({ title: 'Novo' });
+      expect(result).toEqual({ id: 1, title: 'Novo' });
+    });
+
+    // Cenário: Tarefa não encontrada retorna null
+    it('deve retornar null se tarefa não encontrada', async () => {
+      (Task.findByPk as jest.Mock).mockResolvedValue(null);
+      const result = await TasksRepo.updateById(999, { title: 'Novo' });
+      expect(result).toBeNull();
+    });
+
+    // Cenário: Erro ao buscar tarefa
+    it('deve propagar erro de Task.findByPk', async () => {
+      const error = new Error('fail');
+      (Task.findByPk as jest.Mock).mockRejectedValue(error);
+      await expect(TasksRepo.updateById(1, { title: 'Novo' })).rejects.toThrow(error);
+    });
+
+    // Cenário: Erro ao atualizar tarefa
+    it('deve propagar erro de task.update', async () => {
+      const mockTask = { update: jest.fn().mockRejectedValue(new Error('update fail')) };
+      (Task.findByPk as jest.Mock).mockResolvedValue(mockTask);
+      await expect(TasksRepo.updateById(1, { title: 'Novo' })).rejects.toThrow('update fail');
+    });
+  });
+
+  describe('deleteById', () => {
+    // Cenário: Remoção bem-sucedida
+    it('deve remover tarefa por id', async () => {
+      (Task.destroy as jest.Mock).mockResolvedValue(1);
+      const result = await TasksRepo.deleteById(1);
+      expect(Task.destroy).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(result).toBe(1);
+    });
+
+    // Cenário: Remoção retorna 0 (não encontrado)
+    it('deve retornar 0 se tarefa não encontrada', async () => {
+      (Task.destroy as jest.Mock).mockResolvedValue(0);
+      const result = await TasksRepo.deleteById(999);
+      expect(result).toBe(0);
+    });
+
+    // Cenário: Erro ao remover tarefa
+    it('deve propagar erro de Task.destroy', async () => {
+      const error = new Error('fail');
+      (Task.destroy as jest.Mock).mockRejectedValue(error);
+      await expect(TasksRepo.deleteById(1)).rejects.toThrow(error);
+    });
+  });
+
+  describe('findById', () => {
+    // Cenário: Busca por ID retorna tarefa
+    it('deve buscar tarefa por id', async () => {
+      (Task.findByPk as jest.Mock).mockResolvedValue({ id: 1 });
+      const result = await TasksRepo.findById(1);
+      expect(Task.findByPk).toHaveBeenCalledWith(1);
+      expect(result).toEqual({ id: 1 });
+    });
+
+    // Cenário: Busca por ID não encontrada
+    it('deve retornar null se não encontrar tarefa', async () => {
+      (Task.findByPk as jest.Mock).mockResolvedValue(null);
+      const result = await TasksRepo.findById(999);
+      expect(result).toBeNull();
+    });
+
+    // Cenário: Erro ao buscar tarefa por id
+    it('deve propagar erro de Task.findByPk', async () => {
+      const error = new Error('fail');
+      (Task.findByPk as jest.Mock).mockRejectedValue(error);
+      await expect(TasksRepo.findById(1)).rejects.toThrow(error);
+    });
+  });
+});

--- a/tests/unit/services/cache.service.test.ts
+++ b/tests/unit/services/cache.service.test.ts
@@ -1,0 +1,92 @@
+import { InMemoryCache } from '../../../src/services/cache.service';
+
+describe('InMemoryCache', () => {
+  let cache: InMemoryCache;
+  let now: number;
+
+  beforeEach(() => {
+    cache = new InMemoryCache();
+    now = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Cenário: Instanciação com TTL padrão
+  it('// Cenário: Instanciação padrão deve definir TTL de 10 minutos', () => {
+    const c = new InMemoryCache();
+    expect((c as any).defaultTtlMs).toBe(10 * 60 * 1000);
+  });
+
+  // Cenário: Instanciação com TTL customizado
+  it('// Cenário: Instanciação customizada deve definir TTL informado', () => {
+    const c = new InMemoryCache(12345);
+    expect((c as any).defaultTtlMs).toBe(12345);
+  });
+
+  // Cenário: Armazena valor com TTL padrão e recupera antes de expirar
+  it('// Cenário: set/get recupera valor antes do TTL expirar', () => {
+    cache.set('key', 'valor');
+    expect(cache.get<string>('key')).toBe('valor');
+  });
+
+  // Cenário: Armazena valor com TTL customizado e recupera antes de expirar
+  it('// Cenário: set/get recupera valor com TTL customizado', () => {
+    cache.set('key', 42, 5000);
+    expect(cache.get<number>('key')).toBe(42);
+  });
+
+  // Cenário: Recupera valor de tipo diferente (tipagem)
+  it('// Cenário: get retorna valor com tipagem correta', () => {
+    cache.set('key', { a: 1 });
+    const val = cache.get<{ a: number }>('key');
+    expect(val).toEqual({ a: 1 });
+  });
+
+  // Cenário: Chave não existe retorna null
+  it('// Cenário: get retorna null se chave não existe', () => {
+    expect(cache.get('inexistente')).toBeNull();
+  });
+
+  // Cenário: Valor expirado retorna null e deleta do cache
+  it('// Cenário: get retorna null se valor expirou e remove do cache', () => {
+    cache.set('key', 'valor', 1000);
+    now += 1001;
+    expect(cache.get('key')).toBeNull();
+    // Chave foi removida do store
+    expect((cache as any).store.has('key')).toBe(false);
+  });
+
+  // Cenário: Armazena valor com TTL zero (expira imediatamente)
+  it('// Cenário: set com TTL zero expira imediatamente', () => {
+    cache.set('key', 'valor', 0);
+    expect(cache.get('key')).toBe('valor');
+  });
+
+  // Cenário: Armazena valor undefined/null como valor
+  it('// Cenário: set/get aceita valor undefined', () => {
+    cache.set('key', undefined);
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  it('// Cenário: set/get aceita valor null', () => {
+    cache.set('key', null);
+    expect(cache.get('key')).toBeNull();
+  });
+
+  // Cenário: Chave vazia funciona normalmente
+  it('// Cenário: set/get aceita chave vazia', () => {
+    cache.set('', 'abc');
+    expect(cache.get('')).toBe('abc');
+  });
+
+  // Cenário: Chave/valor/TTL tipos errados não quebram (edge case)
+  it('// Cenário: set/get aceita tipos estranhos', () => {
+    cache.set(123 as any, 'num');
+    expect(cache.get(123 as any)).toBe('num');
+    cache.set('key', [1, 2, 3]);
+    expect(cache.get<number[]>('key')).toEqual([1, 2, 3]);
+  });
+});

--- a/tests/unit/services/github.service.test.ts
+++ b/tests/unit/services/github.service.test.ts
@@ -1,0 +1,214 @@
+// Testes unitários para src/services/github.service.ts
+// Observações: mocks para axios, cache e ProjectsRepo; cada it contém comentário de cenário
+
+jest.mock('axios');
+jest.mock('../../../src/services/cache.service', () => ({
+  cache: { get: jest.fn(), set: jest.fn() },
+}));
+jest.mock('../../../src/repositories/projects.repo', () => ({
+  ProjectsRepo: { findById: jest.fn() },
+}));
+
+import axios from 'axios';
+
+import { ProjectsRepo } from '../../../src/repositories/projects.repo';
+import { cache } from '../../../src/services/cache.service';
+import { GitHubService } from '../../../src/services/github.service';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedCache = cache as unknown as { get: jest.Mock; set: jest.Mock };
+const mockedProjectsRepo = ProjectsRepo as unknown as { findById: jest.Mock };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  delete process.env.GITHUB_TOKEN;
+});
+
+describe('GitHubService.fetchAndAttach', () => {
+  // Cenário: projeto inexistente -> deve lançar erro 404
+  it('throws 404 when Projeto não encontrado', async () => {
+    // Arrange
+    mockedProjectsRepo.findById.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(GitHubService.fetchAndAttach(1, 'any')).rejects.toMatchObject({
+      message: 'Projeto não encontrado',
+      status: 404,
+    });
+
+    expect(mockedProjectsRepo.findById).toHaveBeenCalledWith(1);
+  });
+
+  // Cenário: cache contém os repositórios -> não deve chamar axios e deve usar cache
+  it('uses cached repos when available and updates project', async () => {
+    // Arrange
+    const cached = [
+      {
+        id: 1,
+        name: 'r1',
+        html_url: 'http://x/1',
+        description: null,
+        stargazers_count: 0,
+        forks_count: 0,
+        language: null,
+        created_at: '2020-01-01T00:00:00Z',
+        updated_at: '2020-01-02T00:00:00Z',
+      },
+    ] as const;
+
+    const project = { id: 42, update: jest.fn().mockResolvedValue(undefined) };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+    mockedCache.get.mockReturnValue(cached);
+
+    // Act
+    const res = await GitHubService.fetchAndAttach(42, 'me');
+
+    // Assert
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(project.update).toHaveBeenCalledWith({ githubRepos: cached });
+    expect(res).toEqual({ projectId: 42, username: 'me', repos: cached });
+  });
+
+  // Cenário: cache vazio -> faz request ao GitHub, mapeia, seta cache e atualiza projeto (com token)
+  it('fetches from GitHub when cache miss, sets cache and updates project (with token)', async () => {
+    // Arrange
+    process.env.GITHUB_TOKEN = 'secrettoken';
+    mockedCache.get.mockReturnValue(undefined);
+
+    const repoItems = [
+      {
+        id: 1,
+        name: 'a',
+        html_url: 'u1',
+        description: null,
+        stargazers_count: 1,
+        forks_count: 1,
+        language: 'TS',
+        created_at: '2020-01-01',
+        updated_at: '2020-01-10',
+      },
+      {
+        id: 2,
+        name: 'b',
+        html_url: 'u2',
+        description: 'd',
+        stargazers_count: 2,
+        forks_count: 2,
+        language: 'JS',
+        created_at: '2020-01-01',
+        updated_at: '2020-01-09',
+      },
+      {
+        id: 3,
+        name: 'c',
+        html_url: 'u3',
+        description: null,
+        stargazers_count: 3,
+        forks_count: 3,
+        language: null,
+        created_at: '2020-01-01',
+        updated_at: '2020-01-08',
+      },
+      {
+        id: 4,
+        name: 'd',
+        html_url: 'u4',
+        description: null,
+        stargazers_count: 4,
+        forks_count: 4,
+        language: 'Go',
+        created_at: '2020-01-01',
+        updated_at: '2020-01-07',
+      },
+      {
+        id: 5,
+        name: 'e',
+        html_url: 'u5',
+        description: null,
+        stargazers_count: 5,
+        forks_count: 5,
+        language: 'Py',
+        created_at: '2020-01-01',
+        updated_at: '2020-01-06',
+      },
+      {
+        id: 6,
+        name: 'f',
+        html_url: 'u6',
+        description: null,
+        stargazers_count: 6,
+        forks_count: 6,
+        language: 'Rust',
+        created_at: '2020-01-01',
+        updated_at: '2020-01-05',
+      },
+    ];
+
+    mockedAxios.get.mockResolvedValue({ data: repoItems });
+
+    const project = { id: 7, update: jest.fn().mockResolvedValue(undefined) };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+
+    // Act
+    const res = await GitHubService.fetchAndAttach(7, 'token-user');
+
+    // Assert
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    const calledUrl = mockedAxios.get.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('users/token-user/repos');
+    const options = mockedAxios.get.mock.calls[0][1] as any;
+    expect(options.headers.Authorization).toBe(`Bearer ${process.env.GITHUB_TOKEN}`);
+
+    expect(mockedCache.set).toHaveBeenCalledTimes(1);
+    const cachedArg = mockedCache.set.mock.calls[0][1];
+    expect(Array.isArray(cachedArg)).toBe(true);
+    expect(cachedArg).toHaveLength(5);
+
+    expect(project.update).toHaveBeenCalledWith({ githubRepos: cachedArg });
+    expect(res).toEqual({ projectId: 7, username: 'token-user', repos: cachedArg });
+  });
+
+  // Cenário: cache vazio -> faz request ao GitHub sem token (sem Authorization header)
+  it('fetches from GitHub when cache miss and no token present (no Authorization header)', async () => {
+    // Arrange
+    mockedCache.get.mockReturnValue(undefined);
+    mockedAxios.get.mockResolvedValue({ data: [] });
+
+    const project = { id: 8, update: jest.fn().mockResolvedValue(undefined) };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+
+    // Act
+    const res = await GitHubService.fetchAndAttach(8, 'user with space');
+
+    // Assert
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    const calledUrl = mockedAxios.get.mock.calls[0][0] as string;
+    expect(calledUrl).toContain(encodeURIComponent('user with space'));
+    const options = mockedAxios.get.mock.calls[0][1] as any;
+    expect(options.headers.Authorization).toBeUndefined();
+
+    expect(mockedCache.set).toHaveBeenCalledWith('gh:user with space:last5', []);
+    expect(project.update).toHaveBeenCalledWith({ githubRepos: [] });
+    expect(res).toEqual({ projectId: 8, username: 'user with space', repos: [] });
+  });
+
+  // Cenário: error na requisição axios -> propaga erro
+  it('propagates axios error when request fails', async () => {
+    // Arrange
+    mockedCache.get.mockReturnValue(undefined);
+    const networkErr = new Error('Network fail');
+    mockedAxios.get.mockRejectedValue(networkErr);
+
+    const project = { id: 9, update: jest.fn().mockResolvedValue(undefined) };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+
+    // Act & Assert
+    await expect(GitHubService.fetchAndAttach(9, 'erruser')).rejects.toBe(networkErr);
+  });
+});

--- a/tests/unit/services/projects.service.test.ts
+++ b/tests/unit/services/projects.service.test.ts
@@ -1,0 +1,132 @@
+// Testes unitários para src/services/projects.service.ts
+
+jest.mock('../../../src/repositories/projects.repo', () => ({
+  ProjectsRepo: {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findById: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+  },
+}));
+
+import { ProjectsRepo } from '../../../src/repositories/projects.repo';
+import { ProjectsService } from '../../../src/services/projects.service';
+
+const mockedProjectsRepo = ProjectsRepo as unknown as {
+  create: jest.Mock;
+  findAll: jest.Mock;
+  findById: jest.Mock;
+  updateById: jest.Mock;
+  deleteById: jest.Mock;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ProjectsService', () => {
+  // Cenário: create deve encaminhar payload para o repositório e retornar o projeto criado
+  it('create: forwards payload to ProjectsRepo.create and returns created project', async () => {
+    // Arrange
+    const payload = { name: 'Novo', description: null, status: 'active' as const };
+    const created = { id: 1, ...payload };
+    mockedProjectsRepo.create.mockResolvedValue(created);
+
+    // Act
+    const res = await ProjectsService.create(payload);
+
+    // Assert
+    expect(mockedProjectsRepo.create).toHaveBeenCalledWith(payload);
+    expect(res).toEqual(created);
+  });
+
+  // Cenário: list retorna lista de projetos (inclui caso vazio)
+  it('list: returns array of projects (including empty array)', async () => {
+    // Arrange
+    const list = [{ id: 1, name: 'p1' }];
+    mockedProjectsRepo.findAll.mockResolvedValue(list);
+
+    // Act
+    const res = await ProjectsService.list();
+
+    // Assert
+    expect(mockedProjectsRepo.findAll).toHaveBeenCalled();
+    expect(res).toEqual(list);
+
+    // Edge: empty list
+    mockedProjectsRepo.findAll.mockResolvedValue([]);
+    const resEmpty = await ProjectsService.list();
+    expect(resEmpty).toEqual([]);
+  });
+
+  // Cenário: get retorna projeto se encontrado
+  it('get: returns project when found', async () => {
+    // Arrange
+    const project = { id: 2, name: 'p2' };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+
+    // Act
+    const res = await ProjectsService.get(2);
+
+    // Assert
+    expect(mockedProjectsRepo.findById).toHaveBeenCalledWith(2);
+    expect(res).toEqual(project);
+  });
+
+  // Cenário: get lança 404 quando projeto não encontrado
+  it('get: throws 404 when Projeto não encontrado', async () => {
+    // Arrange
+    mockedProjectsRepo.findById.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(ProjectsService.get(999)).rejects.toMatchObject({
+      message: 'Projeto não encontrado',
+      status: 404,
+    });
+  });
+
+  // Cenário: update retorna objeto quando updateById encontra e atualiza
+  it('update: returns updated project when updateById succeeds', async () => {
+    // Arrange
+    const payload = { name: 'Updated' };
+    const updated = { id: 3, ...payload };
+    mockedProjectsRepo.updateById.mockResolvedValue(updated);
+
+    // Act
+    const res = await ProjectsService.update(3, payload);
+
+    // Assert
+    expect(mockedProjectsRepo.updateById).toHaveBeenCalledWith(3, payload);
+    expect(res).toEqual(updated);
+  });
+
+  // Cenário: update lança 404 quando não existe projeto para atualizar
+  it('update: throws 404 when updateById returns null', async () => {
+    // Arrange
+    mockedProjectsRepo.updateById.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(ProjectsService.update(123, { name: 'x' })).rejects.toMatchObject({
+      message: 'Projeto não encontrado',
+      status: 404,
+    });
+  });
+
+  // Cenário: remove resolve quando deleteById retorna 1 e lança 404 quando retorna 0
+  it('remove: resolves when deleteById returns positive and throws 404 when zero', async () => {
+    // Arrange: success
+    mockedProjectsRepo.deleteById.mockResolvedValue(1);
+
+    // Act
+    await expect(ProjectsService.remove(5)).resolves.toBeUndefined();
+    expect(mockedProjectsRepo.deleteById).toHaveBeenCalledWith(5);
+
+    // Arrange: failure
+    mockedProjectsRepo.deleteById.mockResolvedValue(0);
+    await expect(ProjectsService.remove(6)).rejects.toMatchObject({
+      message: 'Projeto não encontrado',
+      status: 404,
+    });
+  });
+});

--- a/tests/unit/services/tasks.service.test.ts
+++ b/tests/unit/services/tasks.service.test.ts
@@ -1,0 +1,109 @@
+// Testes unitários para src/services/tasks.service.ts
+
+jest.mock('../../../src/repositories/projects.repo', () => ({
+  ProjectsRepo: { findById: jest.fn() },
+}));
+jest.mock('../../../src/repositories/tasks.repo', () => ({
+  TasksRepo: { create: jest.fn(), updateById: jest.fn(), deleteById: jest.fn() },
+}));
+
+import { ProjectsRepo } from '../../../src/repositories/projects.repo';
+import { TasksRepo } from '../../../src/repositories/tasks.repo';
+import { TasksService } from '../../../src/services/tasks.service';
+
+const mockedProjectsRepo = ProjectsRepo as unknown as { findById: jest.Mock };
+const mockedTasksRepo = TasksRepo as unknown as {
+  create: jest.Mock;
+  updateById: jest.Mock;
+  deleteById: jest.Mock;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2025-08-14T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('TasksService', () => {
+  // Cenário: create lança 404 se projeto não existe
+  it('create throws 404 when Projeto não encontrado', async () => {
+    // Arrange
+    mockedProjectsRepo.findById.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(TasksService.create(1, { title: 't' })).rejects.toMatchObject({
+      message: 'Projeto não encontrado',
+      status: 404,
+    });
+  });
+
+  // Cenário: create cria tarefa com projectId anexado e retorna o resultado
+  it('create creates task and forwards projectId to TasksRepo.create', async () => {
+    // Arrange
+    const project = { id: 10 };
+    mockedProjectsRepo.findById.mockResolvedValue(project);
+    const payload = { title: '', description: undefined, status: null };
+    const created = { id: 99, ...payload, projectId: 10 };
+    mockedTasksRepo.create.mockResolvedValue(created);
+
+    // Act
+    const res = await TasksService.create(10, payload);
+
+    // Assert
+    expect(mockedProjectsRepo.findById).toHaveBeenCalledWith(10);
+    expect(mockedTasksRepo.create).toHaveBeenCalledWith({ ...payload, projectId: 10 });
+    expect(res).toEqual(created);
+  });
+
+  // Cenário: update retorna objeto atualizado quando existe
+  it('update returns updated task when found', async () => {
+    // Arrange
+    const updated = { id: 5, title: 'updated' };
+    mockedTasksRepo.updateById.mockResolvedValue(updated);
+
+    // Act
+    const res = await TasksService.update(5, { title: 'updated' });
+
+    // Assert
+    expect(mockedTasksRepo.updateById).toHaveBeenCalledWith(5, { title: 'updated' });
+    expect(res).toEqual(updated);
+  });
+
+  // Cenário: update lança 404 quando tarefa não encontrada
+  it('update throws 404 when task not found', async () => {
+    // Arrange
+    mockedTasksRepo.updateById.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(TasksService.update(123, { title: 'x' })).rejects.toMatchObject({
+      message: 'Task not found',
+      status: 404,
+    });
+  });
+
+  // Cenário: remove resolve quando deleteById retorna >0
+  it('remove resolves when deleteById returns positive', async () => {
+    // Arrange
+    mockedTasksRepo.deleteById.mockResolvedValue(1);
+
+    // Act & Assert
+    await expect(TasksService.remove(7)).resolves.toBeUndefined();
+    expect(mockedTasksRepo.deleteById).toHaveBeenCalledWith(7);
+  });
+
+  // Cenário: remove lança 404 quando deleteById retorna 0
+  it('remove throws 404 quando deleteById retorna zero', async () => {
+    // Arrange
+    mockedTasksRepo.deleteById.mockResolvedValue(0);
+
+    // Act & Assert
+    await expect(TasksService.remove(8)).rejects.toMatchObject({
+      message: 'Task not found',
+      status: 404,
+    });
+  });
+});


### PR DESCRIPTION
# Descrição da PR
Foram adicionados testes end-to-end, unitários e de configuração para aumentar a cobertura de testes do projeto.
As alterações garantem maior confiabilidade e facilitam a manutenção futura.

---

# Tipo de mudança

- [ ] Nova funcionalidade (feat)
- [ ] Correção de bug (fix)
- [ ] Refatoração (refactor)
- [ ] Ajustes de configuração (chore)
- [ ] Documentação (docs)
- [x] Testes (test)

---

# Alterações realizadas
- Criados testes e2e para projects e tasks

- Adicionados testes de setup e teardown do Jest

- Incluído helper para testes de banco (db.ts)

- Implementados testes unitários para:

- Controllers: projects.controller, tasks.controller

- Models: index, project, task

- Repositories: projects.repo, tasks.repo

- Services: projects.service, tasks.service, github.service, cache.service

---

# Como testar

Passos sugeridos para validar esta PR:

1. Estar executando o projeto com o docker:
docker compose up -d

2. Execute os testes:
Executa testes unitários
npm run test:unit

  Executa testes end-to-end (e2e)
  npm run test:e2e

Executa todos os testes com relatório de cobertura
npm run coverage

---