### PR TITLE
[fix]: Remover validações desnecessárias de username e GITHUB_TOKEN no método fetchAndAttach

### DIFF
--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -31,14 +31,6 @@ export const GitHubService = {
     const project = await ProjectsRepo.findById(projectId);
     if (!project) throw Object.assign(new Error('Projeto não encontrado'), { status: 404 });
 
-    if (!username) {
-      throw Object.assign(new Error('Param "username" é obrigatório'), { status: 400 });
-    }
-
-    if (!process.env.GITHUB_TOKEN) {
-      throw Object.assign(new Error('Env "GITHUB_TOKEN" é obrigatório'), { status: 400 });
-    }
-
     const cacheKey = `gh:${username}:last5`;
     let repos = cache.get<GitHubRepo[]>(cacheKey);
 

--- a/tests/unit/services/github.service.test.ts
+++ b/tests/unit/services/github.service.test.ts
@@ -1,6 +1,3 @@
-// Testes unitários para src/services/github.service.ts
-// Observações: mocks para axios, cache e ProjectsRepo; cada it contém comentário de cenário
-
 jest.mock('axios');
 jest.mock('../../../src/services/cache.service', () => ({
   cache: { get: jest.fn(), set: jest.fn() },


### PR DESCRIPTION
# Descrição da PR

Este PR remove validações desnecessárias relacionadas a username e GITHUB_TOKEN no método fetchAndAttach, permitindo que a integração com o GitHub funcione corretamente para repositórios públicos sem exigir autenticação obrigatória.

---

# Tipo de mudança

- [ ] Nova funcionalidade (feat)
- [x] Correção de bug (fix)
- [ ] Refatoração (refactor)
- [ ] Ajustes de configuração (chore)
- [ ] Documentação (docs)
- [ ] Testes (test)

---

# Alterações realizadas

- Removida validação redundante de username.

- Removida obrigatoriedade de GITHUB_TOKEN para chamadas públicas.

- Ajustado fluxo do método fetchAndAttach para evitar erro 401 em repositórios públicos

---